### PR TITLE
Fixed typo in statement "Make your tool lighting fast"

### DIFF
--- a/src/app/views/home/Home.view.tsx
+++ b/src/app/views/home/Home.view.tsx
@@ -11,7 +11,9 @@ const HomeView: Component = () => {
     <section class={styles.wrapper}>
       <main class={styles.main}>
         <h3 class={`${styles.title} ${utilStyles.stripSpace}`}>
-          <span>Make your tool lighting fast</span>
+          <span>
+            Make your tool lightning fast
+          </span>
           <span class={styles.titleSecondary}>
             <span>with </span>
             <button


### PR DESCRIPTION
Fixed a small typo. The corrected phrase is "lightning fast", which accurately reflects the intended meaning of the statement.